### PR TITLE
configure absolute imports <3

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
       "dom.iterable",
       "esnext"
     ],
+    "paths": {
+      "@/*": ["./*"]
+    },
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,


### PR DESCRIPTION
as a QoL suggestion:

https://nextjs.org/docs/app/building-your-application/configuring/absolute-imports-and-module-aliases

with this you can `import stuff from "@/src/types/types"` instead of the whole `"../../../src/types/types"`