### PR TITLE
Context song selection, new action menu, filehub selection and menu

### DIFF
--- a/azure-functions/prisma/schema.prisma
+++ b/azure-functions/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Session {
   id       String    @id
   albums   Album[]  
   mp3Files mp3File[] 
+  createdAt DateTime  @default(now())
 }
 
 model Album {
@@ -36,6 +37,8 @@ model Album {
   sessionId String    @map("session_id")
   session   Session   @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   mp3Files  mp3File[] 
+
+  @@unique([title, sessionId]) // ensures unique albums
 } 
 
 model mp3File {

--- a/azure-functions/src/functions/GetAlbumsHTTP.ts
+++ b/azure-functions/src/functions/GetAlbumsHTTP.ts
@@ -54,6 +54,7 @@ export async function getAlbumsHTTP(
       },
       songs: album.mp3Files.map((file) => ({
         id: file.id,
+        filePath: file.filePath,
         trackNumber: file.trackNumber,
         title: file.title,
         duration: file.duration ?? "",

--- a/azure-functions/src/functions/UpdateMetadataHTTP.ts
+++ b/azure-functions/src/functions/UpdateMetadataHTTP.ts
@@ -53,45 +53,39 @@ export async function UpdateMetadataHTTP(
   // TODO: Prevent total failiure if promise fails
   // i.e partial updates are good
   try {
-    const updates = ids.map(async (id) => {
-      // Check if albumTitle is being updated and handle album association
-      if (metadata.albumTitle) {
-        // Try to find an existing album with the new title
-        let album = await prisma.album.findFirst({
+    // Use a transaction to ensure atomicity
+    await prisma.$transaction(async (prisma) => {
+      const albumTitle = metadata.albumTitle;
+      let album;
+
+      if (albumTitle) {
+        // Try to find or create an album with the new title within the transaction
+        album = await prisma.album.upsert({
           where: {
-            title: metadata.albumTitle,
+            title_sessionId: {
+              title: albumTitle,
+              sessionId: uuid,
+            },
+          },
+          create: {
+            title: albumTitle,
+            artist: metadata.albumArtist,
             sessionId: uuid,
           },
-        });
-
-        // If no existing album is found, create a new one
-        if (!album) {
-          album = await prisma.album.create({
-            data: {
-              title: metadata.albumTitle,
-              artist: metadata.albumArtist,
-              // You might need to add additional fields such as session ID or artist here
-              sessionId: uuid, // This needs to be dynamically set based on your requirements
-            },
-          });
-          console.log("Created new album");
-        }
-
-        // Update the mp3File with the new albumId and other metadata
-        return prisma.mp3File.update({
-          where: { id: id },
-          data: { ...metadata, albumId: album.id },
-        });
-      } else {
-        // If not updating albumTitle, proceed with a standard update
-        return prisma.mp3File.update({
-          where: { id: id },
-          data: metadata,
+          update: {},
         });
       }
-    });
 
-    await Promise.all(updates);
+      // Update the mp3File records
+      await Promise.all(
+        ids.map((id) =>
+          prisma.mp3File.update({
+            where: { id: id },
+            data: album ? { ...metadata, albumId: album.id } : metadata,
+          })
+        )
+      );
+    });
 
     // After updates, check and delete any empty albums
     const albumsToCheck = await prisma.album.findMany({

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "jszip": "^3.10.1",
         "micro": "^10.0.1",
         "music-metadata-browser": "^2.5.10",
-        "next": "^14.2.3",
+        "next": "^13.5.6",
         "node-id3": "^0.2.6",
         "react": "^18",
         "react-dom": "^18",
@@ -2256,9 +2256,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
+      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.5.4",
@@ -2270,9 +2270,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
-      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz",
+      "integrity": "sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==",
       "cpu": [
         "arm64"
       ],
@@ -2285,9 +2285,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
+      "integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
       "cpu": [
         "x64"
       ],
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
+      "integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
       "cpu": [
         "arm64"
       ],
@@ -2315,9 +2315,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
+      "integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2330,9 +2330,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
-      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
+      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
       "cpu": [
         "x64"
       ],
@@ -2345,9 +2345,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
-      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
+      "integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
       "cpu": [
         "x64"
       ],
@@ -2360,9 +2360,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
+      "integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
       "cpu": [
         "arm64"
       ],
@@ -2375,9 +2375,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
+      "integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
       "cpu": [
         "ia32"
       ],
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
+      "integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
       "cpu": [
         "x64"
       ],
@@ -2601,17 +2601,11 @@
         "vite": "^4.0.0"
       }
     },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
-    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
-        "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
     },
@@ -5028,6 +5022,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "node_modules/globals": {
       "version": "13.23.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
@@ -6141,47 +6140,43 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
-      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
+      "integrity": "sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==",
       "dependencies": {
-        "@next/env": "14.2.3",
-        "@swc/helpers": "0.5.5",
+        "@next/env": "13.5.6",
+        "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
-        "caniuse-lite": "^1.0.30001579",
-        "graceful-fs": "^4.2.11",
+        "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=16.14.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.3",
-        "@next/swc-darwin-x64": "14.2.3",
-        "@next/swc-linux-arm64-gnu": "14.2.3",
-        "@next/swc-linux-arm64-musl": "14.2.3",
-        "@next/swc-linux-x64-gnu": "14.2.3",
-        "@next/swc-linux-x64-musl": "14.2.3",
-        "@next/swc-win32-arm64-msvc": "14.2.3",
-        "@next/swc-win32-ia32-msvc": "14.2.3",
-        "@next/swc-win32-x64-msvc": "14.2.3"
+        "@next/swc-darwin-arm64": "13.5.6",
+        "@next/swc-darwin-x64": "13.5.6",
+        "@next/swc-linux-arm64-gnu": "13.5.6",
+        "@next/swc-linux-arm64-musl": "13.5.6",
+        "@next/swc-linux-x64-gnu": "13.5.6",
+        "@next/swc-linux-x64-musl": "13.5.6",
+        "@next/swc-win32-arm64-msvc": "13.5.6",
+        "@next/swc-win32-ia32-msvc": "13.5.6",
+        "@next/swc-win32-x64-msvc": "13.5.6"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
-          "optional": true
-        },
-        "@playwright/test": {
           "optional": true
         },
         "sass": {
@@ -8157,6 +8152,18 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "jszip": "^3.10.1",
         "micro": "^10.0.1",
         "music-metadata-browser": "^2.5.10",
-        "next": "^13.5.6",
+        "next": "^14.2.3",
         "node-id3": "^0.2.6",
         "react": "^18",
         "react-dom": "^18",
@@ -2256,9 +2256,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
-      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw=="
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
+      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.5.4",
@@ -2270,9 +2270,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz",
-      "integrity": "sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
+      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
       "cpu": [
         "arm64"
       ],
@@ -2285,9 +2285,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
-      "integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
+      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
       "cpu": [
         "x64"
       ],
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
-      "integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
+      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
       "cpu": [
         "arm64"
       ],
@@ -2315,9 +2315,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
-      "integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
+      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
       "cpu": [
         "arm64"
       ],
@@ -2330,9 +2330,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
-      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
+      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
       "cpu": [
         "x64"
       ],
@@ -2345,9 +2345,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
-      "integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
+      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
       "cpu": [
         "x64"
       ],
@@ -2360,9 +2360,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
-      "integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
+      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
       "cpu": [
         "arm64"
       ],
@@ -2375,9 +2375,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
-      "integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
+      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
       "cpu": [
         "ia32"
       ],
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
-      "integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
+      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
       "cpu": [
         "x64"
       ],
@@ -2601,11 +2601,17 @@
         "vite": "^4.0.0"
       }
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
       "dependencies": {
+        "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
     },
@@ -3538,9 +3544,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001547",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
-      "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
+      "version": "1.0.30001620",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
+      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
       "funding": [
         {
           "type": "opencollective",
@@ -5022,11 +5028,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
-    },
     "node_modules/globals": {
       "version": "13.23.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
@@ -6140,43 +6141,47 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
-      "integrity": "sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
+      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
       "dependencies": {
-        "@next/env": "13.5.6",
-        "@swc/helpers": "0.5.2",
+        "@next/env": "14.2.3",
+        "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
-        "caniuse-lite": "^1.0.30001406",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1",
-        "watchpack": "2.4.0"
+        "styled-jsx": "5.1.1"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.5.6",
-        "@next/swc-darwin-x64": "13.5.6",
-        "@next/swc-linux-arm64-gnu": "13.5.6",
-        "@next/swc-linux-arm64-musl": "13.5.6",
-        "@next/swc-linux-x64-gnu": "13.5.6",
-        "@next/swc-linux-x64-musl": "13.5.6",
-        "@next/swc-win32-arm64-msvc": "13.5.6",
-        "@next/swc-win32-ia32-msvc": "13.5.6",
-        "@next/swc-win32-x64-msvc": "13.5.6"
+        "@next/swc-darwin-arm64": "14.2.3",
+        "@next/swc-darwin-x64": "14.2.3",
+        "@next/swc-linux-arm64-gnu": "14.2.3",
+        "@next/swc-linux-arm64-musl": "14.2.3",
+        "@next/swc-linux-x64-gnu": "14.2.3",
+        "@next/swc-linux-x64-musl": "14.2.3",
+        "@next/swc-win32-arm64-msvc": "14.2.3",
+        "@next/swc-win32-ia32-msvc": "14.2.3",
+        "@next/swc-win32-x64-msvc": "14.2.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
           "optional": true
         },
         "sass": {
@@ -8152,18 +8157,6 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
-      }
-    },
-    "node_modules/watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jszip": "^3.10.1",
     "micro": "^10.0.1",
     "music-metadata-browser": "^2.5.10",
-    "next": "^13.5.6",
+    "next": "^14.2.3",
     "node-id3": "^0.2.6",
     "react": "^18",
     "react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jszip": "^3.10.1",
     "micro": "^10.0.1",
     "music-metadata-browser": "^2.5.10",
-    "next": "^14.2.3",
+    "next": "^13.5.6",
     "node-id3": "^0.2.6",
     "react": "^18",
     "react-dom": "^18",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Session {
   id       String    @id
   albums   Album[]  
   mp3Files mp3File[] 
+  createdAt DateTime  @default(now())
 }
 
 model Album {
@@ -36,6 +37,8 @@ model Album {
   sessionId String    @map("session_id")
   session   Session   @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   mp3Files  mp3File[] 
+
+  @@unique([title, sessionId]) // ensures unique albums
 } 
 
 model mp3File {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,12 +5,15 @@ import { ChakraProvider } from "@chakra-ui/react";
 import UUIDProvider from "../contexts/UUIDContext";
 import { theme } from "./theme";
 import { FetchProvider } from "../contexts/FetchContext";
+import { SelectedSongsProvider } from "../contexts/SelectedSongsContext";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ChakraProvider theme={theme}>
       <UUIDProvider>
-        <FetchProvider>{children}</FetchProvider>
+        <FetchProvider>
+          <SelectedSongsProvider>{children}</SelectedSongsProvider>
+        </FetchProvider>
       </UUIDProvider>
     </ChakraProvider>
   );

--- a/src/components/Actions/ActionMenu.tsx
+++ b/src/components/Actions/ActionMenu.tsx
@@ -1,9 +1,17 @@
-import { Card, Stack, Button, Text, useDisclosure } from "@chakra-ui/react";
+import { Card, Stack, Button, Text, Icon } from "@chakra-ui/react";
 
-import { useState, useRef, useEffect } from "react";
-import Edit from "./Edit";
-import Properties from "./Properties";
+import { useRef, useEffect } from "react";
 import { Album, Song } from "../../types/types";
+import {
+  DownloadIcon,
+  EditIcon,
+  InfoIcon,
+  InfoOutlineIcon,
+  MinusIcon,
+  ViewIcon,
+} from "@chakra-ui/icons";
+import { MdRemoveCircleOutline } from "react-icons/md";
+import Link from "next/link";
 
 /**
  * @param position x and y coordinates of the bottom left corner of the menu
@@ -11,21 +19,25 @@ import { Album, Song } from "../../types/types";
  **/
 
 interface ActionMenuComponentProps {
-  songs: Song[];
+  album?: Album | null | undefined;
+  songs?: Song[];
   position: { x: number; y: number };
   onClose: () => void;
   onEditClick: () => void;
   onPropertiesClick: () => void;
   onDownloadClick: () => void;
+  toView: boolean;
 }
 
 export default function ActionMenu({
+  album,
   songs,
   position,
   onClose,
   onEditClick,
   onPropertiesClick,
   onDownloadClick,
+  toView,
 }: ActionMenuComponentProps) {
   // Creates a reference to the Card component
   const cardRef = useRef<HTMLDivElement>(null);
@@ -68,56 +80,64 @@ export default function ActionMenu({
         bg={"brand.200"}
         borderRadius={borderRad}
       >
-        <Button
-          onClick={(event) => {
-            event.stopPropagation();
-            event.preventDefault();
-            onClose();
-            onEditClick();
-          }}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            borderRadius: borderRad,
-            borderBottomLeftRadius: "0",
-            borderBottomRightRadius: "0",
-          }}
-        >
-          <svg
-            width="17px"
-            height="17px"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            color="#ffffff"
-            style={{ marginRight: "0.5rem", marginLeft: "-0.5em" }}
+        {toView ? (
+          <>
+            <Link href={`/editor/${encodeURIComponent(album.album)}`} passHref>
+              <Button
+                w={"100%"}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "flex-start",
+                  borderRadius: borderRad,
+                  borderBottomLeftRadius: "0",
+                  borderBottomRightRadius: "0",
+                }}
+              >
+                <Icon as={ViewIcon} mr="0.5rem" ml="-0.5em" />
+                <Text fontSize={sizeOfFont}>View</Text>
+              </Button>
+            </Link>
+            <Button
+              onClick={(event) => {
+                event.stopPropagation();
+                event.preventDefault();
+                onClose();
+                onEditClick();
+              }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "flex-start",
+                borderRadius: 0,
+              }}
+            >
+              <Icon as={EditIcon} mr="0.5rem" ml="-0.5em" />
+              <Text fontSize={sizeOfFont}>Edit</Text>
+            </Button>
+          </>
+        ) : (
+          <Button
+            onClick={(event) => {
+              event.stopPropagation();
+              event.preventDefault();
+              onClose();
+              onEditClick();
+            }}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "flex-start",
+              borderRadius: borderRad,
+              borderBottomLeftRadius: "0",
+              borderBottomRightRadius: "0",
+            }}
           >
-            <path
-              d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2Z"
-              stroke="#ffffff"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-            <path
-              d="M8 21.1679V14L12 7L16 14V21.1679"
-              stroke="#ffffff"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-            <path
-              d="M8 14C8 14 9.12676 15 10 15C10.8732 15 12 14 12 14C12 14 13.1268 15 14 15C14.8732 15 16 14 16 14"
-              stroke="#ffffff"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-          </svg>
-          <Text fontSize={sizeOfFont}>Edit</Text>
-        </Button>
+            <Icon as={EditIcon} mr="0.5rem" ml="-0.5em"></Icon>
+            <Text fontSize={sizeOfFont}>Edit</Text>
+          </Button>
+        )}
+
         <Button
           onClick={(event) => {
             event.stopPropagation();
@@ -132,38 +152,7 @@ export default function ActionMenu({
             borderRadius: 0,
           }}
         >
-          <svg
-            width="17px"
-            height="17px"
-            stroke-width="2.0"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            color="#ffffff"
-            style={{ marginRight: "0.5rem", marginLeft: "-0.5em" }}
-          >
-            <path
-              d="M12 11.5V16.5"
-              stroke="#ffffff"
-              stroke-width="2.0"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-            <path
-              d="M12 7.51L12.01 7.49889"
-              stroke="#ffffff"
-              stroke-width="2.0"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-            <path
-              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
-              stroke="#ffffff"
-              stroke-width="2.0"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-          </svg>
+          <Icon as={InfoOutlineIcon} mr="0.5rem" ml="-0.5em" />
           <Text fontSize={sizeOfFont}>Properties</Text>
         </Button>
         <Button
@@ -180,38 +169,7 @@ export default function ActionMenu({
             borderRadius: 0,
           }}
         >
-          <svg
-            width="17px"
-            height="17px"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            color="#ffffff"
-            style={{ marginRight: "0.5rem", marginLeft: "-0.5em" }}
-          >
-            <path
-              d="M9 17L15 17"
-              stroke="#ffffff"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-            <path
-              d="M12 6V13M12 13L15.5 9.5M12 13L8.5 9.5"
-              stroke="#ffffff"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-            <path
-              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
-              stroke="#ffffff"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-          </svg>
+          <Icon as={DownloadIcon} mr="0.5rem" ml="-0.5em" />
           <Text fontSize={sizeOfFont}>Download</Text>
         </Button>
         <Button
@@ -224,31 +182,7 @@ export default function ActionMenu({
             borderTopRightRadius: "0",
           }}
         >
-          <svg
-            width="17px"
-            height="17px"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            color="#ffffff"
-            style={{ marginRight: "0.5rem", marginLeft: "-0.5em" }}
-          >
-            <path
-              d="M8 12H16"
-              stroke="#ffffff"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-            <path
-              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
-              stroke="#ffffff"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-          </svg>
+          <Icon as={MinusIcon} mr="0.5rem" ml="-0.5em" />
           <Text fontSize={sizeOfFont}>Remove</Text>
         </Button>
       </Stack>

--- a/src/components/Actions/ActionMenu.tsx
+++ b/src/components/Actions/ActionMenu.tsx
@@ -80,7 +80,7 @@ export default function ActionMenu({
         bg={"brand.200"}
         borderRadius={borderRad}
       >
-        {toView ? (
+        {toView && album ? (
           <>
             <Link href={`/editor/${encodeURIComponent(album.album)}`} passHref>
               <Button

--- a/src/components/Album-detail/SongDisplay.tsx
+++ b/src/components/Album-detail/SongDisplay.tsx
@@ -33,10 +33,12 @@ import {
   TimeIcon,
   WarningIcon,
 } from "@chakra-ui/icons";
+import { useSelectedSongs } from "../../contexts/SelectedSongsContext";
 
 export function SongDisplay({ album }: { album: Album }) {
   const { uuid } = useUUID();
-  const [selectedSongs, setSelectedSongs] = useState<string[]>([]);
+  // const [selectedSongs, setSelectedSongs] = useState<string[]>([]);
+  const { selectedSongs, setSelectedSongs } = useSelectedSongs();
   const [rightClickedSong, setRightClickedSong] = useState<Song | null>(null);
   const [rightClickPosition, setRightClickPosition] = useState({ x: 0, y: 0 });
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);

--- a/src/components/Album-detail/SongDisplay.tsx
+++ b/src/components/Album-detail/SongDisplay.tsx
@@ -348,12 +348,12 @@ export function SongDisplay({ album }: { album: Album }) {
       </CardBody>
       {rightClickedSong && (
         <ActionMenu
-          songs={selectedSongObjects}
           position={rightClickPosition}
           onClose={closeMenu}
           onEditClick={openEditModal}
           onPropertiesClick={openPropertiesModal}
           onDownloadClick={handleDownload}
+          toView={false}
         />
       )}
       <Edit

--- a/src/components/Album-detail/SongDisplay.tsx
+++ b/src/components/Album-detail/SongDisplay.tsx
@@ -177,6 +177,12 @@ export function SongDisplay({ album }: { album: Album }) {
     setRightClickPosition({ x: event.clientX, y: event.clientY });
   };
 
+  const handleContainerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      setSelectedSongs([]);
+    }
+  };
+
   // Handle download
   const toast = useToast();
   const handleDownload = async () => {
@@ -250,6 +256,7 @@ export function SongDisplay({ album }: { album: Album }) {
       rounded={"xl"}
       maxHeight="calc(100vh - 90px)"
       overflow={"hidden"}
+      onClick={handleContainerClick} // deselects everything when clicked on container
     >
       <AlbumInfoSection album={album} />
       <HStack

--- a/src/components/Albums-main/AlbumDisplayItem.tsx
+++ b/src/components/Albums-main/AlbumDisplayItem.tsx
@@ -13,9 +13,11 @@ import {
   Icon,
 } from "@chakra-ui/react";
 import Link from "next/link";
-import { Album, Song } from "../../types/types";
+import { Album, CommonSongProperties, Song } from "../../types/types";
 import { MdOutlineQueueMusic } from "react-icons/md";
 import { calculateCommonProperties } from "../../util/commonprops";
+import { useState, useEffect } from "react";
+import { renderImageAlbumItem } from "../../util/generateimage";
 
 // Remove this and add to func header instead
 interface AlbumDisplayItemProps {
@@ -23,62 +25,17 @@ interface AlbumDisplayItemProps {
 }
 
 export function AlbumDisplayItem({ album }: AlbumDisplayItemProps) {
-  const commonProperties = calculateCommonProperties(album.songs);
-  const renderImageDisplay = () => {
-    const imagesSet = album.songs
-      .map((song) => song.image)
-      .filter((image) => image);
+  const [commonProperties, setCommonProperties] =
+    useState<CommonSongProperties>(calculateCommonProperties(album.songs));
+  const [imageDisplay, setImageDisplay] = useState<JSX.Element | null>(null);
 
-    const images = Array.from(imagesSet);
+  useEffect(() => {
+    setCommonProperties(calculateCommonProperties(album.songs));
+  }, [album]);
 
-    if (images.length === 0) {
-      return (
-        <Center w="100%" h="100%" bg={"brand.200"}>
-          <Icon
-            as={MdOutlineQueueMusic}
-            w={10}
-            h={10}
-            color="brand.400"
-            bg={"brand.200"}
-            borderRadius={"5px"}
-          />
-        </Center>
-      );
-    }
-
-    if (images.length < 4 || commonProperties.image !== "Various") {
-      return (
-        <Image
-          src={images[0]}
-          p={2}
-          borderRadius={"15"}
-          alt={"Album Cover"}
-          w="100%"
-        />
-      );
-    }
-
-    return (
-      <Grid
-        templateColumns="repeat(2, 1fr)"
-        templateRows="repeat(2, 1fr)"
-        gap={1}
-        p={2}
-      >
-        {images.slice(0, 4).map((image, index) => (
-          <GridItem key={index}>
-            <Image
-              src={image}
-              alt={`Album Cover ${index + 1}`}
-              objectFit="cover"
-              borderRadius="5px"
-              boxSize="100%"
-            />
-          </GridItem>
-        ))}
-      </Grid>
-    );
-  };
+  useEffect(() => {
+    setImageDisplay(renderImageAlbumItem(album, commonProperties));
+  }, [album, commonProperties]);
 
   return (
     <WrapItem>
@@ -109,7 +66,7 @@ export function AlbumDisplayItem({ album }: AlbumDisplayItemProps) {
               templateColumns="repeat(6, 1fr)"
             >
               <GridItem rowSpan={6} colSpan={6}>
-                {renderImageDisplay()}
+                {imageDisplay}
               </GridItem>
               <GridItem colSpan={6} rowSpan={1} pl={2} pr={2}>
                 <Text as="b" align="left" noOfLines={1}>

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -77,8 +77,23 @@ export function FileHub() {
   const [rightClickPosition, setRightClickPosition] = useState({ x: 0, y: 0 });
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isPropertiesModalOpen, setIsPropertiesModalOpen] = useState(false);
+  const [toView, setToView] = useState(false);
+  const [selectedAlbum, setSelectedAlbum] = useState<Album | null>(null);
 
-  const handleRightClick = (
+  const handleAlbumRightClick = (
+    album: Album,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    event.preventDefault();
+    setIsRightClicked(true);
+    setRightClickPosition({ x: event.clientX, y: event.clientY });
+    setToView(true); // Set toView to true for FileHubAlbum right-click
+    setSelectedAlbum(album); // Set selected album
+    const songIds = album.songs.map((song) => song.id); // Extract song IDs
+    setSelectedSongs(songIds); // Set the selected songs
+  };
+
+  const handleCardRightClick = (
     songId: string,
     event: React.MouseEvent<HTMLDivElement>
   ) => {
@@ -88,6 +103,7 @@ export function FileHub() {
     }
     setIsRightClicked(true);
     setRightClickPosition({ x: event.clientX, y: event.clientY });
+    setToView(false);
   };
 
   const closeMenu = () => {
@@ -371,7 +387,8 @@ export function FileHub() {
                   <FileHubAlbum
                     key={index}
                     album={album}
-                    onRightClick={handleRightClick}
+                    onAlbumRightClick={handleAlbumRightClick}
+                    onCardRightClick={handleCardRightClick}
                   />
                 );
               })
@@ -379,12 +396,14 @@ export function FileHub() {
           </Accordion>
           {isRightClicked && (
             <ActionMenu
+              album={selectedAlbum}
               songs={selectedSongObjects}
               position={rightClickPosition}
               onClose={closeMenu}
               onEditClick={openEditModal}
               onPropertiesClick={openPropertiesModal}
-              onDownloadClick={handleDownload} //
+              onDownloadClick={handleDownload}
+              toView={toView}
             />
           )}
           <Edit

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -363,20 +363,10 @@ export function FileHub() {
                 ))}
               </React.Fragment>
             ) : (
-              //   albums &&
-              //   albums.length > 0 &&
-              //   albums.map((album, index) => (
-              //     <FileHubAlbum
-              //       key={index}
-              //       album={album}
-              //       onRightClick={handleRightClick}
-              //     />
-              //   ))
-              // )}
               albums &&
               albums.length > 0 &&
               albums.map((album, index) => {
-                console.log(album.album); // Log the album object here
+                // console.log(album.album); // REMOVE
                 return (
                   <FileHubAlbum
                     key={index}

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -321,7 +321,7 @@ export function FileHub() {
                 boxShadow: "none",
               },
             }}
-            onContextMenu={handleRightClick}
+            // onContextMenu={handleRightClick} idk what this is
           >
             {!isLoaded ? (
               // "Lets you group elements without a wrapper node"

--- a/src/components/FileHub/FileHubAlbum.tsx
+++ b/src/components/FileHub/FileHubAlbum.tsx
@@ -17,11 +17,16 @@ import { renderImageFromAlbumSmall } from "../../util/generateimage";
 
 export function FileHubAlbum({
   album,
-  onRightClick,
+  onCardRightClick,
+  onAlbumRightClick,
 }: {
   album: Album;
-  onRightClick: (
+  onCardRightClick: (
     songId: string,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => void;
+  onAlbumRightClick: (
+    album: Album,
     event: React.MouseEvent<HTMLDivElement>
   ) => void;
 }) {
@@ -59,48 +64,52 @@ export function FileHubAlbum({
 
   return (
     <AccordionItem>
-      <AccordionButton>
-        <Box
-          as="button"
-          w="100%"
-          borderTopRadius={"lg"}
-          borderBottomRadius={isClicked ? "none" : "lg"}
-          h="55px"
-          overflow="hidden"
-          transition="background-color 0.2s ease"
-          _hover={
-            isClicked
-              ? undefined
-              : { bg: "brand.400", _dark: { bg: "brand.300" } }
-          }
-          onClick={handleClick} // Attach the click event handler
-          bg={isClicked ? "brand.400" : isHovered ? "brand.400" : "transparent"} // Update the background color based on isClicked state and hover state
-          _dark={{
-            bg: isClicked
-              ? "brand.400"
-              : isHovered
-              ? "brand.300"
-              : "transparent",
-          }}
-          cursor={"pointer"}
-          onMouseOver={handleHover} // Attach the hover event handler
-          onMouseLeave={handleMouseLeave} // Attach the mouse leave event handler
-        >
-          <HStack spacing="10px">
-            {imageDisplay}
-            <Text noOfLines={1} maxW={200} align="left">
-              {commonProperties.albumTitle}
-            </Text>
-          </HStack>
-        </Box>
-      </AccordionButton>
+      <Box onContextMenu={(e) => onAlbumRightClick(album, e)}>
+        <AccordionButton>
+          <Box
+            as="button"
+            w="100%"
+            borderTopRadius={"lg"}
+            borderBottomRadius={isClicked ? "none" : "lg"}
+            h="55px"
+            overflow="hidden"
+            transition="background-color 0.2s ease"
+            _hover={
+              isClicked
+                ? undefined
+                : { bg: "brand.400", _dark: { bg: "brand.300" } }
+            }
+            onClick={handleClick} // Attach the click event handler
+            bg={
+              isClicked ? "brand.400" : isHovered ? "brand.400" : "transparent"
+            } // Update the background color based on isClicked state and hover state
+            _dark={{
+              bg: isClicked
+                ? "brand.400"
+                : isHovered
+                ? "brand.300"
+                : "transparent",
+            }}
+            cursor={"pointer"}
+            onMouseOver={handleHover} // Attach the hover event handler
+            onMouseLeave={handleMouseLeave} // Attach the mouse leave event handler
+          >
+            <HStack spacing="10px">
+              {imageDisplay}
+              <Text noOfLines={1} maxW={200} align="left">
+                {commonProperties.albumTitle}
+              </Text>
+            </HStack>
+          </Box>
+        </AccordionButton>
+      </Box>
       <AccordionPanel>
         {album.songs.map((song, index) => (
           <FileHubAlbumCard
             key={song.id}
             isLast={index === album.songs.length - 1}
             song={song}
-            onRightClick={onRightClick}
+            onRightClick={onCardRightClick}
           />
         ))}
       </AccordionPanel>

--- a/src/components/FileHub/FileHubAlbum.tsx
+++ b/src/components/FileHub/FileHubAlbum.tsx
@@ -4,25 +4,27 @@
 import React, { useEffect, useState } from "react";
 import {
   Box,
-  Center,
   HStack,
-  Image,
   Text,
   AccordionItem,
   AccordionButton,
   AccordionPanel,
-  Skeleton,
-  Grid,
-  GridItem,
-  Icon,
 } from "@chakra-ui/react";
 import { FileHubAlbumCard } from "./FileHubAlbumCard";
 import { Album, CommonSongProperties, Song } from "../../types/types";
-import { MdOutlineQueueMusic } from "react-icons/md";
 import { calculateCommonProperties } from "../../util/commonprops";
 import { renderImageFromAlbumSmall } from "../../util/generateimage";
 
-export function FileHubAlbum({ album }: { album: Album }) {
+export function FileHubAlbum({
+  album,
+  onRightClick,
+}: {
+  album: Album;
+  onRightClick: (
+    songId: string,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => void;
+}) {
   const [imageDisplay, setImageDisplay] = useState<JSX.Element | null>(null);
   const [commonProperties, setCommonProperties] =
     useState<CommonSongProperties>(calculateCommonProperties(album.songs));
@@ -98,6 +100,7 @@ export function FileHubAlbum({ album }: { album: Album }) {
             key={song.id}
             isLast={index === album.songs.length - 1}
             song={song}
+            onRightClick={onRightClick}
           />
         ))}
       </AccordionPanel>

--- a/src/components/FileHub/FileHubAlbumCard.tsx
+++ b/src/components/FileHub/FileHubAlbumCard.tsx
@@ -53,15 +53,15 @@ export function FileHubAlbumCard({
       onMouseLeave={() => setIsHovered(false)}
     >
       <VStack alignItems={"left"} pl={"15px"} py={"5px"} gap={"0px"}>
-        <Text fontSize={"15px"} noOfLines={1} pt={"2px"}>
+        <Text fontSize={"15px"} noOfLines={1} pt={"2px"} userSelect="none">
           {song.title}
         </Text>
-        <Text fontSize={"10px"} noOfLines={1} pb={"3px"}>
+        <Text fontSize={"10px"} noOfLines={1} pb={"3px"} userSelect="none">
           {song.artist}
         </Text>
       </VStack>
       <Flex alignItems={"center"} pr={"15px"} maxWidth={"40%"}>
-        <Text fontFamily={"mono"} fontSize={"15px"}>
+        <Text fontFamily={"mono"} fontSize={"15px"} userSelect="none">
           {convertTime(song.duration)}
         </Text>
       </Flex>

--- a/src/components/FileHub/FileHubAlbumCard.tsx
+++ b/src/components/FileHub/FileHubAlbumCard.tsx
@@ -3,35 +3,32 @@ import React, { useState } from "react";
 import { Flex, Text, VStack } from "@chakra-ui/react";
 import { Album, Song } from "../../types/types";
 import { convertTime } from "../../util/duration";
+import { useSelectedSongs } from "../../contexts/SelectedSongsContext";
 
 export function FileHubAlbumCard({
   song,
   isLast = false,
+  onRightClick,
 }: {
   song: Song;
   isLast?: boolean;
+  onRightClick: (
+    songId: string,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => void;
 }) {
-  const [isClicked, setIsClicked] = useState(false);
+  const { selectedSongs, setSelectedSongs } = useSelectedSongs();
+  const isSelected = selectedSongs.includes(song.id);
 
-  // Function to handle the click event
-  const handleClick = () => {
-    // Toggle the isClicked state when the card is clicked
-    setIsClicked(!isClicked);
-  };
-
-  // Function to handle hover effect
-  const handleHover = () => {
-    // Apply hover effect only if the card is not already selected
-    if (!isClicked) {
-      setIsHovered(true);
-    }
-  };
-
-  // Function to handle mouse leave
-  const handleMouseLeave = () => {
-    // Remove hover effect only if the card is not already selected
-    if (!isClicked) {
-      setIsHovered(false);
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.ctrlKey || event.metaKey) {
+      setSelectedSongs((prev) =>
+        prev.includes(song.id)
+          ? prev.filter((id) => id !== song.id)
+          : [...prev, song.id]
+      );
+    } else {
+      setSelectedSongs([song.id]);
     }
   };
 
@@ -42,17 +39,18 @@ export function FileHubAlbumCard({
       justifyContent={"space-between"}
       transition="background-color 0.2s ease"
       _hover={
-        isClicked ? undefined : { bg: "brand.400", _dark: { bg: "brand.300" } }
+        isSelected ? undefined : { bg: "brand.400", _dark: { bg: "brand.300" } }
       }
       onClick={handleClick}
+      onContextMenu={(event) => onRightClick(song.id, event)}
       borderRadius={"none"}
-      borderBottomRadius={isLast ? "lg" : "none"} // If last time in mapped list, add radius
-      bg={isClicked ? "brand.400" : isHovered ? "brand.400" : "transparent"} // Update the background color based on isClicked state and hover state
+      borderBottomRadius={isLast ? "lg" : "none"}
+      bg={isSelected ? "brand.400" : isHovered ? "brand.400" : "transparent"}
       _dark={{
-        bg: isClicked ? "brand.400" : isHovered ? "brand.300" : "transparent",
+        bg: isSelected ? "brand.400" : isHovered ? "brand.300" : "transparent",
       }}
-      onMouseOver={handleHover} // Attach the hover event handler
-      onMouseLeave={handleMouseLeave} // Attach the mouse leave event handler
+      onMouseOver={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <VStack alignItems={"left"} pl={"15px"} py={"5px"} gap={"0px"}>
         <Text fontSize={"15px"} noOfLines={1} pt={"2px"}>

--- a/src/components/Testing/UploadTest.tsx
+++ b/src/components/Testing/UploadTest.tsx
@@ -5,15 +5,19 @@ import {
   CardBody,
   CardFooter,
   CardHeader,
+  FormControl,
+  FormLabel,
   Heading,
+  Input,
   Text,
 } from "@chakra-ui/react";
 import { useUUID } from "../../contexts/UUIDContext";
 import { Link } from "@chakra-ui/next-js";
 
 export default function UploadTest() {
-  const { uuid, generateUUID } = useUUID();
+  const { uuid, generateUUID, setNewUUID } = useUUID();
   const [files, setFiles] = useState<FileList | null>(null);
+  const [newUUID, setNewUUIDValue] = useState<string>("");
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const fileList = event.target.files;
@@ -46,6 +50,12 @@ export default function UploadTest() {
     }
   };
 
+  const handleUUIDSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setNewUUID(newUUID);
+    setNewUUIDValue(""); // Clear the input field
+  };
+
   return (
     <Card
       p={"20px"}
@@ -62,6 +72,20 @@ export default function UploadTest() {
       </CardHeader>
       <CardBody>
         <Button onClick={generateUUID}>Generate new UUID</Button>
+
+        <form onSubmit={handleUUIDSubmit}>
+          <FormControl mt={4}>
+            <FormLabel>Set New UUID</FormLabel>
+            <Input
+              value={newUUID}
+              onChange={(e) => setNewUUIDValue(e.target.value)}
+              placeholder="Enter new UUID"
+            />
+            <Button type="submit" mt={2}>
+              Submit
+            </Button>
+          </FormControl>
+        </form>
         {/* Input for file selection */}
         {/* <Button as="label" htmlFor="fileInput" cursor="pointer">
           Upload Files

--- a/src/contexts/SelectedSongsContext.tsx
+++ b/src/contexts/SelectedSongsContext.tsx
@@ -1,13 +1,26 @@
-// contexts/SelectedSongsContext.js
-
+// contexts/SelectedSongsContext.tsx
 import React, { createContext, useContext, useState } from "react";
 
-const SelectedSongsContext = createContext([]);
+interface SelectedSongsContextType {
+  selectedSongs: string[];
+  setSelectedSongs: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+const SelectedSongsContext = createContext<SelectedSongsContextType>({
+  selectedSongs: [],
+  setSelectedSongs: () => {},
+});
 
 export const useSelectedSongs = () => useContext(SelectedSongsContext);
 
-export const SelectedSongsProvider = ({ children }) => {
-  const [selectedSongs, setSelectedSongs] = useState([]);
+interface SelectedSongsProviderProps {
+  children: React.ReactNode;
+}
+
+export const SelectedSongsProvider = ({
+  children,
+}: SelectedSongsProviderProps) => {
+  const [selectedSongs, setSelectedSongs] = useState<string[]>([]);
 
   const value = {
     selectedSongs,

--- a/src/contexts/SelectedSongsContext.tsx
+++ b/src/contexts/SelectedSongsContext.tsx
@@ -1,0 +1,22 @@
+// contexts/SelectedSongsContext.js
+
+import React, { createContext, useContext, useState } from "react";
+
+const SelectedSongsContext = createContext([]);
+
+export const useSelectedSongs = () => useContext(SelectedSongsContext);
+
+export const SelectedSongsProvider = ({ children }) => {
+  const [selectedSongs, setSelectedSongs] = useState([]);
+
+  const value = {
+    selectedSongs,
+    setSelectedSongs,
+  };
+
+  return (
+    <SelectedSongsContext.Provider value={value}>
+      {children}
+    </SelectedSongsContext.Provider>
+  );
+};

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -6,6 +6,7 @@ export interface Album {
 
 export interface Song {
   id: string;
+  filePath: string;
   trackNumber: number;
   title: string;
   duration: string;

--- a/src/util/generateimage.tsx
+++ b/src/util/generateimage.tsx
@@ -337,3 +337,60 @@ export function HoverableImage({
     </Box>
   );
 }
+
+export function renderImageAlbumItem(album, commonProperties) {
+  const imagesSet = new Set(
+    album.songs
+      .map((song) => song.image)
+      .filter((image): image is string => typeof image === "string")
+  );
+  const images = Array.from(imagesSet) as string[];
+
+  if (images.length === 0) {
+    return (
+      <Center w="100%" h="100%" bg={"brand.200"}>
+        <Icon
+          as={MdOutlineQueueMusic}
+          w={10}
+          h={10}
+          color="brand.400"
+          bg={"brand.200"}
+          borderRadius={"5px"}
+        />
+      </Center>
+    );
+  }
+
+  if (images.length < 4 || commonProperties.image !== "Various") {
+    return (
+      <Image
+        src={images[0]}
+        p={2}
+        borderRadius={"15"}
+        alt={"Album Cover"}
+        w="100%"
+      />
+    );
+  }
+
+  return (
+    <Grid
+      templateColumns="repeat(2, 1fr)"
+      templateRows="repeat(2, 1fr)"
+      gap={1}
+      p={2}
+    >
+      {images.slice(0, 4).map((image, index) => (
+        <GridItem key={index}>
+          <Image
+            src={image}
+            alt={`Album Cover ${index + 1}`}
+            objectFit="cover"
+            borderRadius="5px"
+            boxSize="100%"
+          />
+        </GridItem>
+      ))}
+    </Grid>
+  );
+}


### PR DESCRIPTION
- Prisma schema updated to have unique constraint for uuid and album title (prevents dup albums and fixes "various" albums popping up)
- Added filePath to GetAlbumsHTTP which aligns with the same line being added to types (this will be used later for untagged albums)
- Upgraded UpdateMetadataHTTP to use prisma transactions and delete empty albums after updating (prevents dup albums again)
- SelectedSongsProvider added to providers for context setup and sharing of selected songs
- Revamped action menu to display differently if rightclicked over a filehub album vs filehub albumcard
- Replaced action menu icons with new ones 
- Updated filehub and songdisplay to use new selected songs context
- Condensed image collage generation for AlbumDisplayItem and fixed set issue, now correctly generates image collage. Condensed function in util folder
- Right clicking filehub album automatically selects all songs in it
- Added selection features to filehub, excluding shift click
- Added an input box and submit button for UUID test page to set a new UUID
