### PR TITLE
Feature/search sort filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "axios": "^1.6.8",
         "encoding": "^0.1.13",
         "framer-motion": "^10.16.4",
+        "fuse.js": "^7.0.0",
         "jszip": "^3.10.1",
         "micro": "^10.0.1",
         "music-metadata-browser": "^2.5.10",
@@ -4957,6 +4958,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-intrinsic": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.6.8",
     "encoding": "^0.1.13",
     "framer-motion": "^10.16.4",
+    "fuse.js": "^7.0.0",
     "jszip": "^3.10.1",
     "micro": "^10.0.1",
     "music-metadata-browser": "^2.5.10",

--- a/src/app/editor/layout.tsx
+++ b/src/app/editor/layout.tsx
@@ -1,24 +1,13 @@
 "use client";
 
 import { Providers } from "../providers";
-import {
-  Box,
-  Button,
-  Center,
-  Fade,
-  Flex,
-  Grid,
-  GridItem,
-  HStack,
-  useColorModeValue,
-} from "@chakra-ui/react";
+import { Box, Center, Flex } from "@chakra-ui/react";
 import NextLink, { type LinkProps as NextLinkProps } from "next/link";
 import { chakra } from "@chakra-ui/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/react";
 import { FileHub } from "../../components/FileHub/FileHub";
 import { useState, useEffect } from "react";
-import { DragHandleIcon } from "@chakra-ui/icons";
 
 const LinkButton = chakra<typeof NextLink, NextLinkProps>(NextLink, {
   // ensure that you're forwarding all of the required props for your case
@@ -66,6 +55,7 @@ export default function RootLayout({
     document.body.addEventListener("mousemove", onMouseMove);
     document.body.addEventListener("mouseup", onMouseUp, { once: true });
   };
+
   return (
     <Providers>
       <Flex

--- a/src/app/editor/layout.tsx
+++ b/src/app/editor/layout.tsx
@@ -57,7 +57,8 @@ export default function RootLayout({
   };
 
   return (
-    <Providers>
+    // <Providers>
+    <>
       <Flex
         bg="black"
         h="100vh"
@@ -149,6 +150,6 @@ export default function RootLayout({
       </Flex>
       <SpeedInsights />
       <Analytics />
-    </Providers>
+    </>
   );
 }

--- a/src/app/editor/songs/page.tsx
+++ b/src/app/editor/songs/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Album, Song } from "../../../types/types";
+import { useUUID } from "../../../contexts/UUIDContext";
+import { SongDisplayLoading } from "../../../components/Album-detail/SongDisplayLoading";
+import { SongDisplay } from "../../../components/Album-detail/SongDisplay";
+import { useFetch } from "../../../contexts/FetchContext";
+
+export default function SongsPage() {
+  const { uuid } = useUUID();
+  const { fetchAlbums, refetchData } = useFetch();
+  const [allSongs, setAllSongs] = useState<Song[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const fetchAllSongs = async () => {
+      try {
+        const albums = await fetchAlbums(uuid);
+        if (albums) {
+          const songs = albums.flatMap((album) => album.songs);
+          setAllSongs(songs);
+          setIsLoaded(true);
+        }
+      } catch (error) {
+        setError("Failed to fetch songs: " + error.message);
+        console.error(error);
+        setIsLoaded(true);
+      }
+    };
+
+    fetchAllSongs();
+  }, [fetchAlbums, uuid, refetchData]);
+
+  if (!isLoaded) {
+    return <SongDisplayLoading />;
+  }
+
+  if (allSongs.length > 0) {
+    const allSongsAlbum: Album = {
+      album: "All Songs",
+      artist: "",
+      songs: allSongs,
+    };
+
+    return <SongDisplay album={allSongsAlbum} />;
+  }
+
+  return null;
+}

--- a/src/components/Album-detail/AlbumInfoSection.tsx
+++ b/src/components/Album-detail/AlbumInfoSection.tsx
@@ -6,12 +6,14 @@ import { calculateTotalDuration } from "../../util/duration";
 import { calculateCommonProperties } from "../../util/commonprops";
 import { useState, useEffect } from "react";
 import { renderImageFromAlbumLarge } from "../../util/generateimage";
+import { useSelectedSongs } from "../../contexts/SelectedSongsContext";
 
 export function AlbumInfoSection({ album }: { album: Album }) {
   const totalDuration = calculateTotalDuration(album.songs);
   const [imageDisplay, setImageDisplay] = useState<JSX.Element | null>(null);
   const [commonProperties, setCommonProperties] =
     useState<CommonSongProperties>(calculateCommonProperties(album.songs));
+  const { selectedSongs, setSelectedSongs } = useSelectedSongs();
 
   useEffect(() => {
     setCommonProperties(calculateCommonProperties(album.songs));
@@ -21,8 +23,14 @@ export function AlbumInfoSection({ album }: { album: Album }) {
     setImageDisplay(renderImageFromAlbumLarge(album, commonProperties));
   }, [album, commonProperties]);
 
+  const handleContainerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      setSelectedSongs([]);
+    }
+  };
+
   return (
-    <HStack align={"start"}>
+    <HStack align={"start"} onClick={handleContainerClick}>
       {imageDisplay}
       <VStack align={"start"} w={"100%"}>
         <Text fontSize={"4xl"} as="b" noOfLines={1}>

--- a/src/components/Album-detail/SongDisplay.tsx
+++ b/src/components/Album-detail/SongDisplay.tsx
@@ -49,25 +49,38 @@ export function SongDisplay({ album }: { album: Album }) {
   });
 
   // sorting songs
+  // sorting songs
+  // sorting songs
   const getSortedSongs = () => {
     return [...album.songs].sort((a, b) => {
       const isAsc = sortCriteria.order === "asc";
-      let aValue = a[sortCriteria.field];
-      let bValue = b[sortCriteria.field];
+      let aValue, bValue;
 
       if (sortCriteria.field === "duration") {
-        aValue = parseInt(aValue);
-        bValue = parseInt(bValue);
+        aValue = parseInt(a.duration);
+        bValue = parseInt(b.duration);
+      } else if (sortCriteria.field === "album") {
+        aValue = a.albumTitle.toLowerCase();
+        bValue = b.albumTitle.toLowerCase();
+      } else if (sortCriteria.field === "trackNumber") {
+        aValue = a.trackNumber;
+        bValue = b.trackNumber;
+      } else {
+        aValue = a[sortCriteria.field].toLowerCase();
+        bValue = b[sortCriteria.field].toLowerCase();
+      }
+
+      if (sortCriteria.field === "trackNumber") {
         return isAsc ? aValue - bValue : bValue - aValue;
       } else {
-        if (a[sortCriteria.field] < b[sortCriteria.field]) {
+        if (aValue < bValue) {
           return isAsc ? -1 : 1;
         }
-        if (a[sortCriteria.field] > b[sortCriteria.field]) {
+        if (aValue > bValue) {
           return isAsc ? 1 : -1;
         }
+        return 0;
       }
-      return 0;
     });
   };
 
@@ -336,19 +349,18 @@ export function SongDisplay({ album }: { album: Album }) {
       >
         <Box>
           {sortedSongs.length === 0 ? (
-            <Box>
-              Upload files to start
-            </Box>
+            <Box>Upload files to start</Box>
           ) : (
-          sortedSongs.map((song, index) => (
-            <SongGridCard
-              key={song.id}
-              song={song}
-              isSelected={selectedSongs.includes(song.id)}
-              onClick={handleSelectSong}
-              onRightClick={handleRightClick}
-            />
-          )))}
+            sortedSongs.map((song, index) => (
+              <SongGridCard
+                key={song.id}
+                song={song}
+                isSelected={selectedSongs.includes(song.id)}
+                onClick={handleSelectSong}
+                onRightClick={handleRightClick}
+              />
+            ))
+          )}
         </Box>
       </CardBody>
       {rightClickedSong && (

--- a/src/components/Albums-main/AlbumDisplayItem.tsx
+++ b/src/components/Albums-main/AlbumDisplayItem.tsx
@@ -77,7 +77,11 @@ export function AlbumDisplayItem({ album }: AlbumDisplayItemProps) {
               {/* i.e, empty space between contents and border is not even all around */}
               <GridItem colSpan={6} rowSpan={1} pl={2} pr={2}>
                 <Text align="left" noOfLines={1} fontSize={"xs"}>
-                  {commonProperties.albumArtist}
+                  {commonProperties?.albumArtist
+                    ? commonProperties.albumArtist
+                    : album.songs.length > 0 && album.songs[0].artist
+                    ? album.songs[0].artist
+                    : ""}
                 </Text>
               </GridItem>
             </Grid>

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -1,7 +1,7 @@
 // app/providers.tsx
 "use client";
 
-import { ChevronDownIcon, SearchIcon } from "@chakra-ui/icons";
+import { ChevronDownIcon, ChevronUpIcon, SearchIcon } from "@chakra-ui/icons";
 import {
   Button,
   Card,
@@ -56,6 +56,7 @@ export function FileHub() {
       try {
         const albums = await fetchAlbums(uuid);
         setAlbums(albums);
+        setInitialAlbums(albums);
         setIsLoaded(true);
       } catch (error) {
         setError("Failed to fetch albums: " + error.message);
@@ -79,6 +80,26 @@ export function FileHub() {
   const [isPropertiesModalOpen, setIsPropertiesModalOpen] = useState(false);
   const [toView, setToView] = useState(false);
   const [selectedAlbum, setSelectedAlbum] = useState<Album | null>(null);
+  const [sortOrder, setSortOrder] = useState<"default" | "asc" | "desc">(
+    "default"
+  );
+  const [initialAlbums, setInitialAlbums] = useState<Album[] | null>(null);
+
+  useEffect(() => {
+    if (albums) {
+      if (sortOrder === "asc") {
+        setAlbums([...albums].sort((a, b) => a.album.localeCompare(b.album)));
+      } else if (sortOrder === "desc") {
+        setAlbums([...albums].sort((a, b) => b.album.localeCompare(a.album)));
+      } else if (sortOrder === "default" && initialAlbums) {
+        setAlbums(initialAlbums);
+      }
+    }
+  }, [sortOrder, albums]);
+
+  const handleSortOrderChange = (order: "default" | "asc" | "desc") => {
+    setSortOrder(order);
+  };
 
   const handleAlbumRightClick = (
     album: Album,
@@ -247,28 +268,7 @@ export function FileHub() {
             Upload Files
           </Button>
           <FileUploadBox isOpen={isOpen} onClose={onClose} />
-          <HStack justifyContent={"space-between"}>
-            <Menu closeOnSelect={false}>
-              <MenuButton
-                as={Button}
-                variant="ghost"
-                h="30px"
-                w="70px"
-                bottom="10px"
-              >
-                Filter
-              </MenuButton>
-              <MenuList bg="brand.100">
-                <MenuOptionGroup type="checkbox">
-                  <MenuItemOption bg="brand.100" _hover={{ bg: "brand.200" }}>
-                    Genre
-                  </MenuItemOption>
-                  <MenuItemOption bg="brand.100" _hover={{ bg: "brand.200" }}>
-                    Year
-                  </MenuItemOption>
-                </MenuOptionGroup>
-              </MenuList>
-            </Menu>
+          <HStack justifyContent={"right"}>
             <Menu>
               <MenuButton
                 as={Button}
@@ -281,14 +281,26 @@ export function FileHub() {
                 <ChevronDownIcon />
               </MenuButton>
               <MenuList bg="brand.100">
-                <MenuItem bg="brand.100" _hover={{ bg: "brand.200" }}>
-                  A-Z
+                <MenuItem
+                  bg="brand.100"
+                  _hover={{ bg: "brand.200" }}
+                  onClick={() => handleSortOrderChange("default")}
+                >
+                  Default
                 </MenuItem>
-                <MenuItem bg="brand.100" _hover={{ bg: "brand.200" }}>
-                  Artist
+                <MenuItem
+                  bg="brand.100"
+                  _hover={{ bg: "brand.200" }}
+                  onClick={() => handleSortOrderChange("asc")}
+                >
+                  A-Z <ChevronUpIcon />
                 </MenuItem>
-                <MenuItem bg="brand.100" _hover={{ bg: "brand.200" }}>
-                  Recently Added
+                <MenuItem
+                  bg="brand.100"
+                  _hover={{ bg: "brand.200" }}
+                  onClick={() => handleSortOrderChange("desc")}
+                >
+                  Z-A <ChevronDownIcon />
                 </MenuItem>
               </MenuList>
             </Menu>

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -101,15 +101,21 @@ export function FileHub() {
 
   useEffect(() => {
     if (albums) {
+      let filteredAlbums = filterAlbumsAndSongs(albums, searchQuery);
       if (sortOrder === "asc") {
-        setAlbums([...albums].sort((a, b) => a.album.localeCompare(b.album)));
+        filteredAlbums = [...filteredAlbums].sort((a, b) =>
+          a.album.localeCompare(b.album)
+        );
       } else if (sortOrder === "desc") {
-        setAlbums([...albums].sort((a, b) => b.album.localeCompare(a.album)));
+        filteredAlbums = [...filteredAlbums].sort((a, b) =>
+          b.album.localeCompare(a.album)
+        );
       } else if (sortOrder === "default" && initialAlbums) {
-        setAlbums(initialAlbums);
+        filteredAlbums = initialAlbums;
       }
+      setAlbums(filteredAlbums);
     }
-  }, [sortOrder, albums]);
+  }, [sortOrder, albums, searchQuery, initialAlbums]);
 
   const handleSortOrderChange = (order: "default" | "asc" | "desc") => {
     setSortOrder(order);

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -336,28 +336,35 @@ export function FileHub() {
                 h="30px"
                 w="100px"
                 bottom="10px"
+                color={"whiteAlpha.800"}
               >
                 Sort By:
                 <ChevronDownIcon />
               </MenuButton>
-              <MenuList bg="brand.100">
+              <MenuList bg="brand.200">
                 <MenuItem
-                  bg="brand.100"
-                  _hover={{ bg: "brand.200" }}
+                  bg={sortOrder === "default" ? "brand.400" : "brand.200"}
+                  _hover={{
+                    bg: sortOrder === "default" ? "brand.400" : "brand.300",
+                  }}
                   onClick={() => handleSortOrderChange("default")}
                 >
                   Default
                 </MenuItem>
                 <MenuItem
-                  bg="brand.100"
-                  _hover={{ bg: "brand.200" }}
+                  bg={sortOrder === "asc" ? "brand.400" : "brand.200"}
+                  _hover={{
+                    bg: sortOrder === "asc" ? "brand.400" : "brand.300",
+                  }}
                   onClick={() => handleSortOrderChange("asc")}
                 >
                   A-Z <ChevronUpIcon />
                 </MenuItem>
                 <MenuItem
-                  bg="brand.100"
-                  _hover={{ bg: "brand.200" }}
+                  bg={sortOrder === "desc" ? "brand.400" : "brand.200"}
+                  _hover={{
+                    bg: sortOrder === "desc" ? "brand.400" : "brand.300",
+                  }}
                   onClick={() => handleSortOrderChange("desc")}
                 >
                   Z-A <ChevronDownIcon />

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -40,6 +40,7 @@ import { useFetch } from "../../contexts/FetchContext";
 import { useSelectedSongs } from "../../contexts/SelectedSongsContext";
 import Edit from "../Actions/Edit";
 import Properties from "../Actions/Properties";
+import { useMemo } from "react";
 
 // hardcode data
 // const albumData = require("../../../public/albums.json");
@@ -87,21 +88,41 @@ export function FileHub() {
   const [searchQuery, setSearchQuery] = useState<string>("");
 
   // Searching
-  const filterAlbumsAndSongs = (albums: Album[], query: string) => {
+  // const filterAlbumsAndSongs = (albums: Album[], query: string) => {
+  //   if (!query) return albums;
+  //   const lowercasedQuery = query.toLowerCase();
+  //   return albums.filter(
+  //     (album) =>
+  //       album.album.toLowerCase().includes(lowercasedQuery) ||
+  //       album.songs.some((song) =>
+  //         song.title.toLowerCase().includes(lowercasedQuery)
+  //       )
+  //   );
+  // };
+
+  const filterAlbumsAndSongs = (albums, query) => {
     if (!query) return albums;
     const lowercasedQuery = query.toLowerCase();
     return albums.filter(
       (album) =>
         album.album.toLowerCase().includes(lowercasedQuery) ||
-        album.songs.some((song) =>
-          song.title.toLowerCase().includes(lowercasedQuery)
-        )
+        album.songs.some((song) => {
+          const songTitle = song.title.toLowerCase();
+          if (songTitle.includes(lowercasedQuery)) {
+            console.log(
+              `Match found: "${song.title}" from the album "${album.album}" (matched song title)`
+            );
+            return true;
+          }
+          return false;
+        })
     );
   };
 
   useEffect(() => {
-    if (albums) {
-      let filteredAlbums = filterAlbumsAndSongs(albums, searchQuery);
+    if (initialAlbums) {
+      let filteredAlbums = filterAlbumsAndSongs(initialAlbums, searchQuery);
+
       if (sortOrder === "asc") {
         filteredAlbums = [...filteredAlbums].sort((a, b) =>
           a.album.localeCompare(b.album)
@@ -110,15 +131,20 @@ export function FileHub() {
         filteredAlbums = [...filteredAlbums].sort((a, b) =>
           b.album.localeCompare(a.album)
         );
-      } else if (sortOrder === "default" && initialAlbums) {
-        filteredAlbums = initialAlbums;
       }
+
       setAlbums(filteredAlbums);
     }
-  }, [sortOrder, albums, searchQuery, initialAlbums]);
+  }, [sortOrder, searchQuery, initialAlbums]);
 
   const handleSortOrderChange = (order: "default" | "asc" | "desc") => {
     setSortOrder(order);
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const query = event.target.value;
+    setSearchQuery(query);
+    setSelectedSongs([]); // Deselect all songs when searching
   };
 
   const handleAlbumRightClick = (
@@ -271,6 +297,8 @@ export function FileHub() {
                 boxShadow: "none",
               }}
               type="text"
+              value={searchQuery}
+              onChange={handleSearchChange}
             />
           </InputGroup>
 

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -42,6 +42,7 @@ import Edit from "../Actions/Edit";
 import Properties from "../Actions/Properties";
 import { useMemo } from "react";
 import Fuse from "fuse.js";
+import Link from "next/link";
 
 export function FileHub() {
   const { uuid, generateUUID } = useUUID();
@@ -327,6 +328,39 @@ export function FileHub() {
           >
             Upload Files
           </Button>
+
+          <HStack
+            w={"100%"}
+            justifyContent={"space-between"}
+            borderColor={"brand.400"}
+            mb={2}
+          >
+            <Link href="/editor/songs" style={{ flex: 1 }}>
+              <Button
+                variant="outline"
+                w="100%"
+                bottom="10px"
+                color={"whiteAlpha.800"}
+                _hover={{ bg: "brand.300" }}
+                borderColor={"brand.400"}
+              >
+                All Songs
+              </Button>
+            </Link>
+            <Link href="/editor/albums" style={{ flex: 1 }}>
+              <Button
+                variant="outline"
+                w="100%"
+                bottom="10px"
+                color={"whiteAlpha.800"}
+                _hover={{ bg: "brand.300" }}
+                borderColor={"brand.400"}
+              >
+                Albums
+              </Button>
+            </Link>
+          </HStack>
+
           <FileUploadBox isOpen={isOpen} onClose={onClose} />
           <HStack justifyContent={"right"}>
             <Menu>

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -6,7 +6,6 @@ import {
   ChevronUpIcon,
   Icon,
   Search2Icon,
-  SearchIcon,
 } from "@chakra-ui/icons";
 import {
   Button,
@@ -29,6 +28,7 @@ import {
   Center,
   useToast,
   Spinner,
+  Tooltip,
 } from "@chakra-ui/react";
 import { FileHubAlbum } from "./FileHubAlbum";
 import React, { useEffect, useState } from "react";
@@ -346,10 +346,10 @@ export function FileHub() {
                 borderColor={"brand.400"}
                 bg={"brand.100"}
               >
-                All Songs
+                View all
               </Button>
             </Link>
-            <Link href="/editor/albums" style={{ flex: 1 }}>
+            {/* <Link href="/editor/albums" style={{ flex: 1 }}>
               <Button
                 variant="outline"
                 w="100%"
@@ -360,7 +360,7 @@ export function FileHub() {
               >
                 Albums
               </Button>
-            </Link>
+            </Link> */}
           </HStack>
 
           <FileUploadBox isOpen={isOpen} onClose={onClose} />
@@ -393,14 +393,22 @@ export function FileHub() {
             alignItems="center"
             mb={3}
           >
-            <Link href="/">
-              <Button h="30px" variant={"ghost"} w="20px">
-                <Icon
-                  color={"whiteAlpha.800"}
-                  boxSize={5}
-                  as={MdHomeFilled}
-                ></Icon>
-              </Button>
+            <Link href="/editor/albums">
+              <Tooltip
+                hasArrow
+                label="View Albums"
+                placement="right"
+                bg={"brand.300"}
+                color={"white"}
+              >
+                <Button h="30px" variant={"ghost"} w="20px">
+                  <Icon
+                    color={"whiteAlpha.800"}
+                    boxSize={5}
+                    as={MdHomeFilled}
+                  ></Icon>
+                </Button>
+              </Tooltip>
             </Link>
             <Menu>
               <MenuButton

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -4,6 +4,7 @@
 import {
   ChevronDownIcon,
   ChevronUpIcon,
+  Icon,
   Search2Icon,
   SearchIcon,
 } from "@chakra-ui/icons";
@@ -43,6 +44,7 @@ import Properties from "../Actions/Properties";
 import { useMemo } from "react";
 import Fuse from "fuse.js";
 import Link from "next/link";
+import { MdHomeFilled } from "react-icons/md";
 
 export function FileHub() {
   const { uuid, generateUUID } = useUUID();
@@ -291,7 +293,7 @@ export function FileHub() {
       >
         <Box bg="brand.100">
           <InputGroup
-            pb="5"
+            pb="3"
             w="100%"
             sx={{
               caretColor: "white",
@@ -321,7 +323,7 @@ export function FileHub() {
             bgGradient="linear(to-r, linear.100, linear.200)"
             _hover={{ color: "white", bg: "brand.300" }}
             color={"brand.200"}
-            mb={5}
+            mb={3}
             onClick={() => {
               onOpen();
             }}
@@ -333,16 +335,16 @@ export function FileHub() {
             w={"100%"}
             justifyContent={"space-between"}
             borderColor={"brand.400"}
-            mb={2}
+            mb={3}
           >
             <Link href="/editor/songs" style={{ flex: 1 }}>
               <Button
                 variant="outline"
                 w="100%"
-                bottom="10px"
                 color={"whiteAlpha.800"}
                 _hover={{ bg: "brand.300" }}
                 borderColor={"brand.400"}
+                bg={"brand.100"}
               >
                 All Songs
               </Button>
@@ -351,10 +353,10 @@ export function FileHub() {
               <Button
                 variant="outline"
                 w="100%"
-                bottom="10px"
                 color={"whiteAlpha.800"}
                 _hover={{ bg: "brand.300" }}
                 borderColor={"brand.400"}
+                bg={"brand.100"}
               >
                 Albums
               </Button>
@@ -362,18 +364,54 @@ export function FileHub() {
           </HStack>
 
           <FileUploadBox isOpen={isOpen} onClose={onClose} />
-          <HStack justifyContent={"right"}>
+        </Box>
+        <Box
+          overflowY={"auto"}
+          css={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-start",
+            "&::-webkit-scrollbar": {
+              width: "5px",
+            },
+            "&::-webkit-scrollbar-track": {
+              background: "transparent",
+              borderRadius: "10px",
+            },
+            "&::-webkit-scrollbar-thumb": {
+              background: "#888",
+              borderRadius: "10px",
+            },
+            "&::-webkit-scrollbar-thumb:hover": {
+              background: "#555",
+            },
+          }}
+        >
+          <HStack
+            w={"100%"}
+            justifyContent={"space-between"}
+            alignItems="center"
+            mb={3}
+          >
+            <Link href="/">
+              <Button h="30px" variant={"ghost"} w="20px">
+                <Icon
+                  color={"whiteAlpha.800"}
+                  boxSize={5}
+                  as={MdHomeFilled}
+                ></Icon>
+              </Button>
+            </Link>
             <Menu>
               <MenuButton
                 as={Button}
                 variant="ghost"
                 h="30px"
                 w="100px"
-                bottom="10px"
                 color={"whiteAlpha.800"}
               >
                 Sort By:
-                <ChevronDownIcon />
+                <ChevronDownIcon ml={1} />
               </MenuButton>
               <MenuList bg="brand.200">
                 <MenuItem
@@ -406,29 +444,6 @@ export function FileHub() {
               </MenuList>
             </Menu>
           </HStack>
-        </Box>
-        <Box
-          overflowY={"auto"}
-          css={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            "&::-webkit-scrollbar": {
-              width: "5px",
-            },
-            "&::-webkit-scrollbar-track": {
-              background: "transparent",
-              borderRadius: "10px",
-            },
-            "&::-webkit-scrollbar-thumb": {
-              background: "#888",
-              borderRadius: "10px",
-            },
-            "&::-webkit-scrollbar-thumb:hover": {
-              background: "#555",
-            },
-          }}
-        >
           <Accordion
             index={expandedIndices}
             onChange={(indices) => setExpandedIndices(indices as number[])}

--- a/src/components/FileHub/FileHub.tsx
+++ b/src/components/FileHub/FileHub.tsx
@@ -84,6 +84,20 @@ export function FileHub() {
     "default"
   );
   const [initialAlbums, setInitialAlbums] = useState<Album[] | null>(null);
+  const [searchQuery, setSearchQuery] = useState<string>("");
+
+  // Searching
+  const filterAlbumsAndSongs = (albums: Album[], query: string) => {
+    if (!query) return albums;
+    const lowercasedQuery = query.toLowerCase();
+    return albums.filter(
+      (album) =>
+        album.album.toLowerCase().includes(lowercasedQuery) ||
+        album.songs.some((song) =>
+          song.title.toLowerCase().includes(lowercasedQuery)
+        )
+    );
+  };
 
   useEffect(() => {
     if (albums) {

--- a/src/components/FileHub/FileHubAlbum.tsx
+++ b/src/components/FileHub/FileHubAlbum.tsx
@@ -9,6 +9,7 @@ import {
   AccordionItem,
   AccordionButton,
   AccordionPanel,
+  Highlight,
 } from "@chakra-ui/react";
 import { FileHubAlbumCard } from "./FileHubAlbumCard";
 import { Album, CommonSongProperties, Song } from "../../types/types";
@@ -16,10 +17,15 @@ import { calculateCommonProperties } from "../../util/commonprops";
 import { renderImageFromAlbumSmall } from "../../util/generateimage";
 
 export function FileHubAlbum({
+  key,
   album,
   onCardRightClick,
   onAlbumRightClick,
+  searchQuery,
+  expandedIndices,
+  setExpandedIndices,
 }: {
+  key: number;
   album: Album;
   onCardRightClick: (
     songId: string,
@@ -29,6 +35,9 @@ export function FileHubAlbum({
     album: Album,
     event: React.MouseEvent<HTMLDivElement>
   ) => void;
+  searchQuery: string;
+  expandedIndices: number[];
+  setExpandedIndices: React.Dispatch<React.SetStateAction<number[]>>;
 }) {
   const [imageDisplay, setImageDisplay] = useState<JSX.Element | null>(null);
   const [commonProperties, setCommonProperties] =
@@ -46,6 +55,11 @@ export function FileHubAlbum({
 
   const handleClick = () => {
     setIsClicked(!isClicked);
+    if (!isClicked) {
+      setExpandedIndices((prevIndices) => [...prevIndices, key]);
+    } else {
+      setExpandedIndices((prevIndices) => prevIndices.filter((i) => i !== key));
+    }
   };
 
   const handleHover = () => {
@@ -61,6 +75,17 @@ export function FileHubAlbum({
   };
 
   const [isHovered, setIsHovered] = useState(false);
+
+  const highlightText = (text, query) => {
+    const parts = text.split(new RegExp(`(${query})`, "gi"));
+    return parts.map((part, index) =>
+      part.toLowerCase() === query.toLowerCase() ? (
+        <mark key={index}>{part}</mark>
+      ) : (
+        part
+      )
+    );
+  };
 
   return (
     <AccordionItem>
@@ -81,14 +106,15 @@ export function FileHubAlbum({
             }
             onClick={handleClick} // Attach the click event handler
             bg={
-              isClicked ? "brand.400" : isHovered ? "brand.400" : "transparent"
-            } // Update the background color based on isClicked state and hover state
-            _dark={{
-              bg: isClicked
+              expandedIndices.includes(key) || isHovered
                 ? "brand.400"
-                : isHovered
-                ? "brand.300"
-                : "transparent",
+                : "transparent"
+            }
+            _dark={{
+              bg:
+                expandedIndices.includes(key) || isHovered
+                  ? "brand.300"
+                  : "transparent",
             }}
             cursor={"pointer"}
             onMouseOver={handleHover} // Attach the hover event handler
@@ -97,7 +123,15 @@ export function FileHubAlbum({
             <HStack spacing="10px">
               {imageDisplay}
               <Text noOfLines={1} maxW={200} align="left">
-                {commonProperties.albumTitle}
+                <Highlight
+                  query={searchQuery}
+                  styles={{
+                    bgGradient: "linear(to-r, linear.100, linear.200)",
+                    fontWeight: "bold",
+                  }}
+                >
+                  {commonProperties.albumTitle}
+                </Highlight>
               </Text>
             </HStack>
           </Box>
@@ -110,6 +144,7 @@ export function FileHubAlbum({
             isLast={index === album.songs.length - 1}
             song={song}
             onRightClick={onCardRightClick}
+            searchQuery={searchQuery}
           />
         ))}
       </AccordionPanel>

--- a/src/components/FileHub/FileHubAlbum.tsx
+++ b/src/components/FileHub/FileHubAlbum.tsx
@@ -76,17 +76,6 @@ export function FileHubAlbum({
 
   const [isHovered, setIsHovered] = useState(false);
 
-  const highlightText = (text, query) => {
-    const parts = text.split(new RegExp(`(${query})`, "gi"));
-    return parts.map((part, index) =>
-      part.toLowerCase() === query.toLowerCase() ? (
-        <mark key={index}>{part}</mark>
-      ) : (
-        part
-      )
-    );
-  };
-
   return (
     <AccordionItem>
       <Box onContextMenu={(e) => onAlbumRightClick(album, e)}>

--- a/src/components/FileHub/FileHubAlbumCard.tsx
+++ b/src/components/FileHub/FileHubAlbumCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import { Flex, Text, VStack } from "@chakra-ui/react";
+import { Flex, Text, VStack, Highlight } from "@chakra-ui/react";
 import { Album, Song } from "../../types/types";
 import { convertTime } from "../../util/duration";
 import { useSelectedSongs } from "../../contexts/SelectedSongsContext";
@@ -36,17 +36,6 @@ export function FileHubAlbumCard({
 
   const [isHovered, setIsHovered] = useState(false);
 
-  const highlightText = (text, query) => {
-    const parts = text.split(new RegExp(`(${query})`, "gi"));
-    return parts.map((part, index) =>
-      part.toLowerCase() === query.toLowerCase() ? (
-        <mark key={index}>{part}</mark>
-      ) : (
-        part
-      )
-    );
-  };
-
   return (
     <Flex
       justifyContent={"space-between"}
@@ -67,7 +56,15 @@ export function FileHubAlbumCard({
     >
       <VStack alignItems={"left"} pl={"15px"} py={"5px"} gap={"0px"}>
         <Text fontSize={"15px"} noOfLines={1} pt={"2px"} userSelect="none">
-          {highlightText(song.title, searchQuery)}
+          <Highlight
+            query={searchQuery}
+            styles={{
+              bgGradient: "linear(to-r, linear.100, linear.200)",
+              fontWeight: "bold",
+            }}
+          >
+            {song.title}
+          </Highlight>
         </Text>
         <Text fontSize={"10px"} noOfLines={1} pb={"3px"} userSelect="none">
           {song.artist}

--- a/src/components/FileHub/FileHubAlbumCard.tsx
+++ b/src/components/FileHub/FileHubAlbumCard.tsx
@@ -9,6 +9,7 @@ export function FileHubAlbumCard({
   song,
   isLast = false,
   onRightClick,
+  searchQuery,
 }: {
   song: Song;
   isLast?: boolean;
@@ -16,6 +17,7 @@ export function FileHubAlbumCard({
     songId: string,
     event: React.MouseEvent<HTMLDivElement>
   ) => void;
+  searchQuery: string;
 }) {
   const { selectedSongs, setSelectedSongs } = useSelectedSongs();
   const isSelected = selectedSongs.includes(song.id);
@@ -33,6 +35,17 @@ export function FileHubAlbumCard({
   };
 
   const [isHovered, setIsHovered] = useState(false);
+
+  const highlightText = (text, query) => {
+    const parts = text.split(new RegExp(`(${query})`, "gi"));
+    return parts.map((part, index) =>
+      part.toLowerCase() === query.toLowerCase() ? (
+        <mark key={index}>{part}</mark>
+      ) : (
+        part
+      )
+    );
+  };
 
   return (
     <Flex
@@ -54,7 +67,7 @@ export function FileHubAlbumCard({
     >
       <VStack alignItems={"left"} pl={"15px"} py={"5px"} gap={"0px"}>
         <Text fontSize={"15px"} noOfLines={1} pt={"2px"} userSelect="none">
-          {song.title}
+          {highlightText(song.title, searchQuery)}
         </Text>
         <Text fontSize={"10px"} noOfLines={1} pb={"3px"} userSelect="none">
           {song.artist}


### PR DESCRIPTION
- Removed redundant providers from editor/layout.tsx, this will also prevent UUID from generating twice later on
- Added an "all songs" page using SongDisplay and pre-existing loading skeleton
- Added more left-click containers to deselect songs 
- Fixed SongDisplay sorting func to now properly sort by Album name
- Fixed AlbumDisplayItems not displaying any album artists when there's only one song
- Removed filter button
- Added View all button for "all songs" page to Filehub
- Added home icon for albums page to Filehub with tooltip
- Added functionality to search, with animations for expanding and collapsing accordions (albums) when songs/albums match